### PR TITLE
feat: add MemoLazy function that recomputes value if selected value has changed

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   ],
   "scripts": {
     "compile": "tsc",
+    "test": "tsc && node ./test/main.js",
     "release": "pnpm compile && pnpm publish"
   },
   "devDependencies": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -67,16 +67,9 @@ function equals(firstValue: any, secondValue: any) {
     const keys1 = Object.keys(firstValue);
     const keys2 = Object.keys(secondValue);
   
-    if (keys1.length !== keys2.length) {
-      return false;
-    }
-  
-    for (let key of keys1) {
-      if (firstValue[key] !== secondValue[key]) {
-        return false;
-      }
-    }
-    return true;
+    return keys1.length === keys2.length && keys1.every(key => {
+      return firstValue[key] === secondValue[key]
+    })
   }
 
   // otherwise just compare the values directly

--- a/src/main.ts
+++ b/src/main.ts
@@ -58,20 +58,20 @@ export class MemoLazy<S, V> {
   }
 }
 
-function equals(firstValue: any, secondValue: any) {
-  const isFirstObject = typeof firstValue === 'object' && firstValue !== null;
-  const isSecondObject = typeof secondValue === 'object' && secondValue !== null
+function equals(firstValue: any, secondValue: any): boolean {
+  const isFirstObject = typeof firstValue === "object" && firstValue !== null
+  const isSecondObject = typeof secondValue === "object" && secondValue !== null
 
   // do a shallow comparison of objects, arrays etc.
   if (isFirstObject && isSecondObject) {
-    const keys1 = Object.keys(firstValue);
-    const keys2 = Object.keys(secondValue);
-  
-    return keys1.length === keys2.length && keys1.every(key => {
-      return firstValue[key] === secondValue[key]
+    const keys1 = Object.keys(firstValue)
+    const keys2 = Object.keys(secondValue)
+
+    return keys1.length === keys2.length && keys1.every((key) => {
+      return equals(firstValue[key], secondValue[key])
     })
   }
 
   // otherwise just compare the values directly
-  return firstValue === secondValue;
+  return firstValue === secondValue
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,3 +25,60 @@ export class Lazy<T> {
     this.creator = null
   }
 }
+
+export class MemoLazy<S, V> {
+  private selected: S | undefined = undefined
+  private _value: Promise<V> | undefined = undefined
+
+  constructor(
+    private selector: () => S,
+    private creator: (selected: S) => Promise<V>
+  ) {}
+
+  get hasValue() {
+    return this._value !== undefined
+  }
+
+  get value(): Promise<V> {
+    const selected = this.selector()
+    if (this._value !== undefined && equals(this.selected, selected)) {
+      // value exists and selected hasn't changed, so return the cached value
+      return this._value
+    }
+
+    this.selected = selected
+    const result = this.creator(selected)
+    this.value = result
+
+    return result
+  }
+
+  set value(value: Promise<V>) {
+    this._value = value
+  }
+}
+
+function equals(firstValue: any, secondValue: any) {
+  const isFirstObject = typeof firstValue === 'object' && firstValue !== null;
+  const isSecondObject = typeof secondValue === 'object' && secondValue !== null
+
+  // do a shallow comparison of objects, arrays etc.
+  if (isFirstObject && isSecondObject) {
+    const keys1 = Object.keys(firstValue);
+    const keys2 = Object.keys(secondValue);
+  
+    if (keys1.length !== keys2.length) {
+      return false;
+    }
+  
+    for (let key of keys1) {
+      if (firstValue[key] !== secondValue[key]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // otherwise just compare the values directly
+  return firstValue === secondValue;
+}

--- a/test/main.js
+++ b/test/main.js
@@ -1,0 +1,45 @@
+const { Lazy, MemoLazy } = require("../out/main")
+
+const tests = []
+const it = (message, test) => tests.push({ message, test })
+const assert = (condition) => {
+  if (!condition) throw new Error()
+}
+
+it("[Lazy] reuses the created value even if the selected value has changed", () => {
+  let selectedValue = 0
+  const lazy = new Lazy(() => {
+    return selectedValue * 10
+  })
+
+  selectedValue++
+  assert(lazy.value === 10)
+
+  selectedValue++
+  assert(lazy.value === 10)
+})
+
+it("[MemoLazy] recomputes the created value if the selected value has changed", () => {
+  let selectedValue = 0
+  const lazy = new MemoLazy(
+    () => selectedValue,
+    (selectedValue) => {
+      return selectedValue * 10
+    }
+  )
+
+  selectedValue++
+  assert(lazy.value === 10)
+
+  selectedValue++
+  assert(lazy.value === 20)
+})
+
+tests.forEach((test) => {
+  try {
+    test.test()
+    console.log(`✅ ${test.message}`)
+  } catch (error) {
+    console.error(`❌ ${test.message}`)
+  }
+})


### PR DESCRIPTION
Hi develar, just submitting a PR to add an additional `MemoLazy` function that recomputes the `creator` if the value returned from the `selector` has changed. This is to workaround the following issue within `electron-builder`:

- https://github.com/electron-userland/electron-builder/issues/8280
- https://github.com/electron-userland/electron-builder/pull/8291#discussion_r1663734358

I've avoided adding external libs to minimize the overhead, and I've added two tests to try to illustrate the differences in behaviour.

Feel free to close if you think this is out of scope, or let me know if you have any suggested changes.